### PR TITLE
fix constructor lookup for AOT runtime

### DIFF
--- a/Assets/Colyseus/Runtime/GameDevWare.Serialization/Metadata/MetadataReflection.cs
+++ b/Assets/Colyseus/Runtime/GameDevWare.Serialization/Metadata/MetadataReflection.cs
@@ -197,10 +197,14 @@ namespace GameDevWare.Serialization.Metadata
 			ctrFn = null;
 			defaultConstructor = null;
 
-			if (AotRuntime || type.IsAbstract || type.IsInterface)
+			if (type.IsAbstract || type.IsInterface)
 				return false;
 
 			defaultConstructor = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).FirstOrDefault(ctr => ctr.GetParameters().Length == 0);
+
+			if (AotRuntime && defaultConstructor != null) {
+				return true;
+			}
 
 			if (defaultConstructor == null)
 				return false;


### PR DESCRIPTION
This is fix for 'unable to find default constructor to type 'X' for AOT runtimes like iOS, WebGL etc.