### PR TITLE
Fix cloning of ArraySchema and MapSchema

### DIFF
--- a/Assets/Colyseus/Runtime/Colyseus/Serializer/Schema/Types/ArraySchema.cs
+++ b/Assets/Colyseus/Runtime/Colyseus/Serializer/Schema/Types/ArraySchema.cs
@@ -129,6 +129,7 @@ namespace Colyseus.Schema
             ArraySchema<T> clone = new ArraySchema<T>(items)
             {
                 __callbacks = __callbacks,
+                indexes = indexes
             };
             return clone;
         }

--- a/Assets/Colyseus/Runtime/Colyseus/Serializer/Schema/Types/MapSchema.cs
+++ b/Assets/Colyseus/Runtime/Colyseus/Serializer/Schema/Types/MapSchema.cs
@@ -146,6 +146,7 @@ namespace Colyseus.Schema
             MapSchema<T> clone = new MapSchema<T>(items)
             {
                 __callbacks = __callbacks,
+                Indexes = Indexes
             };
             return clone;
         }


### PR DESCRIPTION
Copy reference to internal indexes dictionary during clone of ArraySchema and MapSchema.

Fixes [#230](https://github.com/colyseus/colyseus-unity-sdk/issues/230).