### PR TITLE
Try to fix no more messages sent after exception.

### DIFF
--- a/Assets/Colyseus/Runtime/WebSocket/WebSocket.cs
+++ b/Assets/Colyseus/Runtime/WebSocket/WebSocket.cs
@@ -496,12 +496,12 @@ namespace NativeWebSocket
                 finally
                 {
                     Monitor.Exit(m_Socket);
-                }
 
-                // Note that we've finished sending.
-                lock (OutgoingMessageLock)
-                {
-                    isSending = false;
+					// Note that we've finished sending.
+					lock (OutgoingMessageLock)
+					{
+						isSending = false;
+					}
                 }
 
                 // Handle any queued messages.


### PR DESCRIPTION
The issue was explain in [issue report](https://github.com/colyseus/colyseus-unity-sdk/issues/232)

I test this in 0.14.21 but this file is the same on master, and I think that it's good to release resource in any case.