### PR TITLE
Avoid Constructor Stripping for ArraySchema & MapSchema

### DIFF
--- a/Assets/Colyseus/Runtime/Colyseus/Serializer/Schema/Types/ArraySchema.cs
+++ b/Assets/Colyseus/Runtime/Colyseus/Serializer/Schema/Types/ArraySchema.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using UnityEngine.Scripting;
 
 namespace Colyseus.Schema
 {
@@ -17,6 +18,7 @@ namespace Colyseus.Schema
 
 		internal HashSet<int> deletedKeys = new HashSet<int>();
 
+		[Preserve]
 		public ArraySchema()
 		{
 			items = new List<T>();

--- a/Assets/Colyseus/Runtime/Colyseus/Serializer/Schema/Types/MapSchema.cs
+++ b/Assets/Colyseus/Runtime/Colyseus/Serializer/Schema/Types/MapSchema.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using UnityEngine.Scripting;
 
 namespace Colyseus.Schema
 {
@@ -18,6 +19,7 @@ namespace Colyseus.Schema
         /// </summary>
         public OrderedDictionary items = new OrderedDictionary();
 
+        [Preserve]
         public MapSchema()
         {
             items = new OrderedDictionary();


### PR DESCRIPTION
Prevent the compiler from stripping the empty constructors for Array and Map Schema in IL2CPP builds.

Fixes #254