### PR TITLE
Added Game Center Authentication Support

### DIFF
--- a/Assets/Colyseus/Runtime/Colyseus/Models/Auth.cs
+++ b/Assets/Colyseus/Runtime/Colyseus/Models/Auth.cs
@@ -101,6 +101,17 @@ namespace Colyseus
 		public Type UserType { get => userType; set => userType = value; }
 	}
 
+	[Serializable]
+	public class GameCenterCredentials
+	{
+		public string playerId;
+		public string bundleId;
+		public long timestamp;
+		public string salt;
+		public string signature;
+		public string publicKeyUrl;
+	}
+
 	/// <summary>
 	///     Colyseus.Auth
 	/// </summary>
@@ -219,6 +230,27 @@ namespace Colyseus
 		public async Task<IAuthData> SignInAnonymously(Dictionary<string, object> options = null)
 		{
 			return await SignInAnonymously<IndexedDictionary<string, object>>(options);
+		}
+
+		public async Task<AuthData<T>> SignInWithGameCenter<T>(GameCenterCredentials credentials)
+		{
+			var response = getAuthData<T>(await _client.Http.Request<AuthData<IndexedDictionary<string, object>>>("POST", $"{PATH}/gamecenter", new Dictionary<string, object>
+			{
+				{ "playerId", credentials.playerId },
+				{ "bundleId", credentials.bundleId },
+				{ "timestamp", credentials.timestamp },
+				{ "salt", credentials.salt },
+				{ "signature", credentials.signature },
+				{ "publicKeyUrl", credentials.publicKeyUrl }
+			}));
+
+			emitChange(response);
+			return response;
+		}
+
+		public async Task<IAuthData> SignInWithGameCenter(GameCenterCredentials credentials)
+		{
+			return await SignInWithGameCenter<IndexedDictionary<string, object>>(credentials);
 		}
 
 		public async Task<AuthData<T>> SignInWithProvider<T>(string providerName, Dictionary<string, object> settings = null)


### PR DESCRIPTION
# Summary
Adds client-side Game Center authentication support to the Colyseus Unity SDK, enabling iOS developers to authenticate users through Apple's Game Center service.

# Changes
- Added `GameCenterCredentials` class with required fields for Game Center authentication
- Added `SignInWithGameCenter<T>()` method for typed authentication responses
- Added `SignInWithGameCenter()` method for generic authentication responses

Integrates with existing auth flow, supports token caching, change callbacks, and error handling

```
Usage
var credentials = new GameCenterCredentials
{
    playerId = "G:123456789",
    bundleId = "com.yourcompany.yourgame",
    timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
    salt = "base64EncodedSalt",
    signature = "base64EncodedSignature",
    publicKeyUrl = "https://static.gc.apple.com/public-key/..."
};

var authData = await client.Auth.SignInWithGameCenter<User>(credentials);
```
# Server Requirements
https://github.com/colyseus/colyseus/pull/885